### PR TITLE
Add cron script for LetsEncrypt/Certbot renewals

### DIFF
--- a/files/renew_letsencrypt.cron
+++ b/files/renew_letsencrypt.cron
@@ -1,0 +1,9 @@
+#!/usr/bin/bash
+
+# Script to trigger LetsEncrypt/Certbot renewals as a cron job. This script was
+# written for someone using the `crontabs` package in Fedora/EPEL RPM
+# repositories. You can drop this file into a directory for the interval you
+# want to run it (e.g. /etc/cron.weekly/).
+
+exec certbot renew
+exit 0

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -48,9 +48,16 @@
 
 - name: add LetsEncrypt renewal hook script
   template:
-      src: znc-renew-letsencrypt.sh
-      dest: /etc/letsencrypt/renewal-hooks/deploy/znc-renew-letsencrypt.sh
-      mode: 0755
+    src: znc-renew-letsencrypt.sh
+    dest: /etc/letsencrypt/renewal-hooks/deploy/znc-renew-letsencrypt.sh
+    mode: 0755
+
+- name: install crontab for renewing Certbot/LetsEncrypt certificates
+  copy:
+    src: renew_letsencrypt.cron
+    dest: /etc/cron.weekly/renew_letsencrypt.cron
+    mode: 0755
+    seuser: system_u
 
 - name: start/enable znc systemd service
   service:


### PR DESCRIPTION
This commit adds a cron script to execute a `certbot renew` command. The
cron script is then installed to `/etc/cron.weekly/` so it is executed
once a week.

This is intended to address the certbot post-renewal script not running.
Somehow the cron job was lost. This puts the cron job into config
management so this problem doesn't happen.

cc: @akarshanbiswas @tjzabel